### PR TITLE
fixing theme previews

### DIFF
--- a/README.md
+++ b/README.md
@@ -181,7 +181,7 @@ omarchy-theme-install https://github.com/j4v3l/omarchy-anonymous-theme
 
 ### [Ash](https://github.com/bjarneo/omarchy-ash-theme)
 
-[![Ash Preview](https://manuals.omamix.org/u/ash-theme-DnGpEy.png)](https://github.com/bjarneo/omarchy-ash-theme)
+[![Ash Preview](https://github.com/bjarneo/omarchy-ash-theme/raw/main/theme.png)](https://github.com/bjarneo/omarchy-ash-theme)
 Install:
 ```
 omarchy-theme-install https://github.com/bjarneo/omarchy-ash-theme

--- a/README.md
+++ b/README.md
@@ -244,7 +244,7 @@ omarchy-theme-install https://github.com/hipsterusername/omarchy-blueridge-dark-
 
 ### [Cobalt2](https://github.com/hoblin/omarchy-cobalt2-theme)
 
-[![Cobalt2 Preview](https://cdn.discordapp.com/attachments/1399365674832232448/1406555777904152687/image0.jpg?ex=68a2e4a5&is=68a19325&hm=afa107206efabec27af557a1af021f5fcc18bdffd453fe7d9938291eb87df252&)](https://github.com/hoblin/omarchy-cobalt2-theme)
+[![Cobalt2 Preview](https://cdn.discordapp.com/attachments/ci/1406555777904152687/image0.jpg?ex=68a2e4a5&is=68a19325&hm=afa107206efabec27af557a1af021f5fcc18bdffd453fe7d9938291eb87df252&)](https://github.com/hoblin/omarchy-cobalt2-theme)
 Install:
 ```
 omarchy-theme-install https://github.com/hoblin/omarchy-cobalt2-theme
@@ -352,7 +352,7 @@ omarchy-theme-install https://github.com/tahayvr/omarchy-gold-rush-theme
 
 ### [Hakker Green](https://github.com/joaquinmeza/omarchy-hakker-green-theme)
 
-[![Hakker Green Preview](https://github.com/joaquinmeza/omarchy-hakker-green-theme/blob/master/backgrounds/hg-01.jpeg?raw=true)](https://github.com/joaquinmeza/omarchy-hakker-green-theme)
+[![Hakker Green Preview](https://github.com/joaquinmeza/omarchy-hakker-green-theme/raw/master/screenshot-2025-08-18_12-07-35.png)](https://github.com/joaquinmeza/omarchy-hakker-green-theme)
 Install:
 ```
 omarchy-theme-install https://github.com/joaquinmeza/omarchy-hakker-green-theme

--- a/README.md
+++ b/README.md
@@ -77,7 +77,7 @@ omarchy-theme-apply gruvbox
 
 ### Osaka Jade
 
-![Osaka Jade Preview](https://learn.omacom.io/u/gruvbox-zTUJ1I.png)
+![Osaka Jade Preview](https://learn.omacom.io/u/osaka-jade-15wLcY.jpg)
 Activate:
 ```
 omarchy-theme-apply osaka-jade

--- a/README.md
+++ b/README.md
@@ -449,15 +449,6 @@ omarchy-theme-install https://github.com/sc0ttman/omarchy-one-dark-pro
 ```
 ---
 
-### [Osaka Jade](https://github.com/Justikun/omarchy-osaka-jade-theme)
-
-[![Osaka Jade Preview](https://camo.githubusercontent.com/9218ac6b949095c9322fd72ce5c08d697bb463be04666d03e8bc32f0f61fae5d/68747470733a2f2f692e696d6775722e636f6d2f756177507766562e6a706567)](https://github.com/Justikun/omarchy-osaka-jade-theme)
-Install:
-```
-omarchy-theme-install https://github.com/Justikun/omarchy-osaka-jade-theme
-```
----
-
 ### [Pretty Cvnt](https://github.com/WalkerMillgress/omarchy-pretty-cvnt-theme)
 
 [![Pretty Cvnt Preview](https://camo.githubusercontent.com/15c00f460a9b4c70fb807286fb29ec1f1aee9626b5799ffa440acc27c1453959/68747470733a2f2f70787363646e2e636f6d2f7075626c69632f6d2f5f76322f3835393630313435323133323134313732322f3333636339623934392d3333393739312f63634a5a584c4b44714541612f4a4a5a746b70334a776c545335376e456a6a43734e48463157556a6e547257356c4e3871685643332e706e67)](https://github.com/WalkerMillgress/omarchy-pretty-cvnt-theme)

--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ Omarchy ships with **nine beautiful, secure, and customizable themes** that styl
 
 ### Tokyo Night
 
-![Tokyo Night Preview](https://manuals.omamix.org/u/tokyo-night-yN9jzd.png)
+![Tokyo Night Preview](https://learn.omacom.io/u/tokyo-night-yN9jzd.png)
 Activate:
 ```
 omarchy-theme-apply tokyo-night
@@ -50,7 +50,7 @@ omarchy-theme-apply tokyo-night
 
 ### Catppuccin
 
-![Catppuccin Preview](https://manuals.omamix.org/u/catppuccin-DEGjke.png)
+![Catppuccin Preview](https://learn.omacom.io/u/catppuccin-DEGjke.png)
 Activate:
 ```
 omarchy-theme-apply catppuccin
@@ -59,7 +59,7 @@ omarchy-theme-apply catppuccin
 
 ### Everforest
 
-![Everforest Preview](https://manuals.omamix.org/u/everforest-VTw7rC.png)
+![Everforest Preview](https://learn.omacom.io/u/everforest-VTw7rC.png)
 Activate:
 ```
 omarchy-theme-apply everforest
@@ -68,16 +68,25 @@ omarchy-theme-apply everforest
 
 ### Gruvbox
 
-![Gruvbox Preview](https://manuals.omamix.org/u/gruvbox-zTUJ1I.png)
+![Gruvbox Preview](https://learn.omacom.io/u/gruvbox-zTUJ1I.png)
 Activate:
 ```
 omarchy-theme-apply gruvbox
 ```
 ---
 
+### Osaka Jade
+
+![Osaka Jade Preview](https://learn.omacom.io/u/gruvbox-zTUJ1I.png)
+Activate:
+```
+omarchy-theme-apply osaka-jade
+```
+---
+
 ### Kanagawa
 
-![Kanagawa Preview](https://manuals.omamix.org/u/kanagawa-qNhehU.png)
+![Kanagawa Preview](https://learn.omacom.io/u/kanagawa-qNhehU.png)
 Activate:
 ```
 omarchy-theme-apply kanagawa
@@ -86,7 +95,7 @@ omarchy-theme-apply kanagawa
 
 ### Nord
 
-![Nord Preview](https://manuals.omamix.org/u/nord-Rd2Y6y.png)
+![Nord Preview](https://learn.omacom.io/u/nord-Rd2Y6y.png)
 Activate:
 ```
 omarchy-theme-apply nord
@@ -95,7 +104,7 @@ omarchy-theme-apply nord
 
 ### Matte Black
 
-![Matte Black Preview](https://manuals.omamix.org/u/2025-07-15-193947_hyprshot-b4lj4R.png)
+![Matte Black Preview](https://learn.omacom.io/u/2025-07-15-193947_hyprshot-b4lj4R.png)
 Activate:
 ```
 omarchy-theme-apply matte-black
@@ -104,7 +113,7 @@ omarchy-theme-apply matte-black
 
 ### Ristretto
 
-![Ristretto Preview](https://manuals.omamix.org/u/ristretto-theme-c99Sux.png)
+![Ristretto Preview](https://learn.omacom.io/u/ristretto-theme-c99Sux.png)
 Activate:
 ```
 omarchy-theme-apply ristretto
@@ -113,7 +122,7 @@ omarchy-theme-apply ristretto
 
 ### Rose Pine
 
-![Rose Pine Preview](https://manuals.omamix.org/u/omarchy-rose-pine-MUH6hH.png)
+![Rose Pine Preview](https://learn.omacom.io/u/omarchy-rose-pine-MUH6hH.png)
 Activate:
 ```
 omarchy-theme-apply rose-pine
@@ -122,7 +131,7 @@ omarchy-theme-apply rose-pine
 
 ### Catppuccin Latte
 
-![Catppuccin Latte Preview](https://manuals.omamix.org/u/catppuccin-latte-theme-1-jrWCjt.png)
+![Catppuccin Latte Preview](https://learn.omacom.io/u/catppuccin-latte-theme-1-jrWCjt.png)
 Activate:
 ```
 omarchy-theme-apply catppuccin-latte


### PR DESCRIPTION
- **adds: Alabaster and Anonymous themes**
- **adds: Vague theme by Rnedlose**
- **updates: Ash theme preview pic**
- **updates: Hakker Green theme prewiew image**
- **updates: all default theme previews**
- **removes: Osaka Jade theme from extras, as it is default now**
- **updates: Osaka Jade preview image source**
