### PR TITLE
Add Dionysus theme

### DIFF
--- a/README.md
+++ b/README.md
@@ -311,6 +311,15 @@ omarchy-theme-install https://github.com/knappkevin/omarchy-crimson-gold-theme
 ```
 ---
 
+### [Dionysus](https://github.com/joeyvigil/omarchy-dionysus-theme)
+
+[![Dionysus Preview](https://github.com/joeyvigil/omarchy-dionysus-theme/raw/main/preview.webp)](https://github.com/joeyvigil/omarchy-dionysus-theme)
+Install:
+```
+omarchy-theme-install https://github.com/joeyvigil/omarchy-dionysus-theme
+```
+---
+
 ### [Dotrb](https://github.com/dotsilva/omarchy-dotrb-theme)
 
 [![Dotrb Preview](https://cdn.discordapp.com/attachments/1399365674832232448/1416222265535627294/preview.png?ex=68d09b44&is=68cf49c4&hm=ad061e4496102439e59e080589848c75ba9b2538d9aa173fb8031cebb33d844c&)](https://github.com/dotsilva/omarchy-dotrb-theme)


### PR DESCRIPTION
Adds **Dionysus** to Extra Omarchy Themes, sorted between Crimson Gold and Dotrb.

A dark theme derived from the [dionysus](https://github.com/pewdiepie-archdaemon/dionysus) Hyprland rice — a One Dark / Nord hybrid keyed on a neon pale cyan (`#9cdef2`), carried across the terminal, bar, menus, lock screen, btop, Helix, Neovim and VS Code.

- Repo: https://github.com/joeyvigil/omarchy-dionysus-theme
- Preview image is served from the theme repo over HTTPS, matching the convention used by the surrounding entries.
- Repo follows the `omarchy-<name>-theme` naming convention, so it installs as `dionysus`.

Entry format matches the existing ones exactly (heading link, linked preview, `Install:` block, `---`).